### PR TITLE
Fix per i layer dei collection tile renderers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 ------------------
 
 - Updated package.json to reflect current addon version [pnicolli]
+- Fixed collection tile renderers layers, they won't show up when this theme is not installed anymore [pnicolli]
 
 
 1.1.7 (2018-02-07)

--- a/src/redturtle/agidtheme/browser/configure.zcml
+++ b/src/redturtle/agidtheme/browser/configure.zcml
@@ -43,7 +43,7 @@
       permission="zope2.View"
       for="*"
       class=".tile_collection_renderers.NewsView"
-      layer="collective.tiles.collection.interfaces.ICollectiveTilesCollectionLayer"
+      layer="redturtle.agidtheme.interfaces.IRedturtleAgidthemeLayer"
       template="templates/news_renderer.pt"
       />
 
@@ -52,7 +52,7 @@
       permission="zope2.View"
       for="*"
       class=".tile_collection_renderers.VideoView"
-      layer="collective.tiles.collection.interfaces.ICollectiveTilesCollectionLayer"
+      layer="redturtle.agidtheme.interfaces.IRedturtleAgidthemeLayer"
       template="templates/video_renderer.pt"
       />
 
@@ -61,7 +61,7 @@
       permission="zope2.View"
       for="*"
       class=".tile_collection_renderers.GalleryView"
-      layer="collective.tiles.collection.interfaces.ICollectiveTilesCollectionLayer"
+      layer="redturtle.agidtheme.interfaces.IRedturtleAgidthemeLayer"
       template="templates/photogallery_renderer.pt"
       />
 
@@ -70,7 +70,7 @@
       permission="zope2.View"
       for="*"
       class=".tile_collection_renderers.AreeTematicheView"
-      layer="collective.tiles.collection.interfaces.ICollectiveTilesCollectionLayer"
+      layer="redturtle.agidtheme.interfaces.IRedturtleAgidthemeLayer"
       template="templates/aree_tematiche.pt"
       />
 
@@ -79,7 +79,7 @@
       permission="zope2.View"
       for="*"
       class=".tile_collection_renderers.OnlineServicesView"
-      layer="collective.tiles.collection.interfaces.ICollectiveTilesCollectionLayer"
+      layer="redturtle.agidtheme.interfaces.IRedturtleAgidthemeLayer"
       template="templates/online_services.pt"
       />
 
@@ -124,7 +124,7 @@
       permission="zope2.View"
       for="*"
       class=".tile_collection_renderers.NewsAreaTematicaView"
-      layer="collective.tiles.collection.interfaces.ICollectiveTilesCollectionLayer"
+      layer="redturtle.agidtheme.interfaces.IRedturtleAgidthemeLayer"
       template="templates/news_area_tematica.pt"
       />
 
@@ -133,7 +133,7 @@
       permission="zope2.View"
       for="*"
       class=".tile_collection_renderers.ServiziAreaTematicaView"
-      layer="collective.tiles.collection.interfaces.ICollectiveTilesCollectionLayer"
+      layer="redturtle.agidtheme.interfaces.IRedturtleAgidthemeLayer"
       template="templates/servizi_area_tematica.pt"
       />
 


### PR DESCRIPTION
Questo fix impedisce ai renderer di comparire nei siti che hanno questo tema nel buildout ma non l'hanno installato.