### PR TITLE
Don't show header viewlet if settings aren't set

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Don't show header viewlet if settings aren't set. Now default settings are set
+  at install-time.
+  [cekk]
 
 
 2.0.0 (2018-03-15)

--- a/src/redturtle/agidtheme/browser/overrides/plone.app.layout.viewlets.portal_header.pt
+++ b/src/redturtle/agidtheme/browser/overrides/plone.app.layout.viewlets.portal_header.pt
@@ -6,24 +6,16 @@
     header_link_url = api.portal.get_registry_record('header_link_url', interface=IRedturtleAgidthemeSettings)
     header_second_link_label = api.portal.get_registry_record('header_second_link_label', interface=IRedturtleAgidthemeSettings)
     header_second_link_url = api.portal.get_registry_record('header_second_link_url', interface=IRedturtleAgidthemeSettings)
-
-    if not header_link_label:
-        header_link_label = 'Governo Italiano'
-    if not header_link_url:
-        header_link_url = 'http://www.governo.it'
-    if not header_second_link_label:
-        header_second_link_label = ''
-    if not header_second_link_url:
-        header_second_link_url = '#'
 ?>
 
-<div id="header-banner">
+<div id="header-banner"
+     tal:condition="python:(header_link_label and header_link_url) or (header_second_link_label and header_second_link_url)">
     <div class="header-banner-inner">
-        <div class="header-banner-owner">
+        <div class="header-banner-owner" tal:condition="python:header_link_label and header_link_url">
             <a href="${header_link_url}" target="_blank">${header_link_label}</a>
         </div>
         <div class="header-banner-second-link"
-             tal:condition="header_second_link_label">
+             tal:condition="python:header_second_link_label and header_second_link_url">
             <a href="${header_second_link_url}" target="_blank">${header_second_link_label}</a>
         </div>
     </div>

--- a/src/redturtle/agidtheme/browser/viewlets.py
+++ b/src/redturtle/agidtheme/browser/viewlets.py
@@ -116,7 +116,7 @@ class HeaderSocialViewlet(base.ViewletBase):
         for link in links:
             try:
                 social, url = link.split('|')
-                cssClass = socialCSSClassDict[social]
+                cssClass = socialCSSClassDict.get(social.strip(), '')
                 res.append({'id': social, 'url': url, 'cssClass': cssClass})
             except ValueError:
                 logger.warning(

--- a/src/redturtle/agidtheme/controlpanel/interfaces.py
+++ b/src/redturtle/agidtheme/controlpanel/interfaces.py
@@ -58,7 +58,8 @@ class IRedturtleAgidthemeSettings(model.Schema):
                 default=u'Header link label'),
         description=_(u'header_link_label_desc',
                       default=u'Label for the link in the header of the site'),
-        required=False
+        required=False,
+        default=u'Governo Italiano'
     )
 
     header_link_url = schema.URI(
@@ -66,7 +67,8 @@ class IRedturtleAgidthemeSettings(model.Schema):
                 default=u'Header link url'),
         description=_(u'header_link_url_desc',
                       default=u'URL of the link in the header'),
-        required=False
+        required=False,
+        default='http://www.governo.it'
     )
 
     header_second_link_label = schema.TextLine(

--- a/src/redturtle/agidtheme/profiles/default/metadata.xml
+++ b/src/redturtle/agidtheme/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-  <version>2000</version>
+  <version>2100</version>
   <dependencies>
     <dependency>profile-collective.tiles.collection:default</dependency>
     <dependency>profile-collective.tiles.advancedstatic:default</dependency>

--- a/src/redturtle/agidtheme/upgrades/configure.zcml
+++ b/src/redturtle/agidtheme/upgrades/configure.zcml
@@ -184,4 +184,12 @@
     handler=".upgrades.import_records_registry"
   />
 
+  <genericsetup:upgradeStep
+    source="2000"
+    destination="2100"
+    profile="redturtle.agidtheme:default"
+    title="Fix default header label and link"
+    description=""
+    handler=".upgrades.fix_default_header_links"
+  />
 </configure>

--- a/src/redturtle/agidtheme/upgrades/upgrades.py
+++ b/src/redturtle/agidtheme/upgrades/upgrades.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 from plone import api
 from plone.registry.interfaces import IRegistry
+from Products.CMFPlone.interfaces.controlpanel import IImagingSchema
 from redturtle.agidtheme import logger
 from redturtle.agidtheme.controlpanel.interfaces import IRedturtleAgidthemeSettings  # noqa
 from zope.component import getUtility
-from Products.CMFPlone.interfaces.controlpanel import IImagingSchema
 
 
 DEFAULT_PROFILE = 'profile-redturtle.agidtheme:default'
@@ -118,3 +118,22 @@ def clean_follow_us_fields(context):
             # entry not present in registry
             continue
     import_records_registry(context)
+
+
+def fix_default_header_links(context):
+    header_link_label = api.portal.get_registry_record(
+        'header_link_label',
+        interface=IRedturtleAgidthemeSettings)
+    header_link_url = api.portal.get_registry_record(
+        'header_link_url',
+        interface=IRedturtleAgidthemeSettings)
+    if not header_link_label:
+        api.portal.set_registry_record(
+            'header_link_label',
+            u'Governo Italiano',
+            interface=IRedturtleAgidthemeSettings)
+    if not header_link_url:
+        api.portal.set_registry_record(
+            'header_link_url',
+            'http://www.governo.it',
+            interface=IRedturtleAgidthemeSettings)


### PR DESCRIPTION
With this change, if one site doesn't want to show the "black header", we just need to unset settings values.

At install-time, default settings are set.
There is also an upgrade-step to set the values if them are empty in existing sites, for backward compatibility.