### PR TITLE
fix uninstall step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 2.2.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix uninstall step
+  [cekk]
 
 
 2.2.2 (2018-07-05)

--- a/src/redturtle/agidtheme/profiles/uninstall/actions.xml
+++ b/src/redturtle/agidtheme/profiles/uninstall/actions.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<object name="portal_actions" meta_type="Plone Actions Tool"
+   xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+ <object name="portal_tabs" meta_type="CMF Action Category">
+  <property name="title">Portal tabs</property>
+  <object name="index_html" meta_type="CMF Action" i18n:domain="plone">
+   <property name="title" i18n:translate="">Home</property>
+   <property name="description" i18n:translate=""></property>
+   <property
+      name="url_expr">string:${globals_view/navigationRootUrl}</property>
+   <property name="link_target"></property>
+   <property name="icon_expr"></property>
+   <property name="available_expr"></property>
+   <property name="permissions">
+    <element value="View"/>
+   </property>
+   <property name="visible">True</property>
+  </object>
+  <object name="aree-tematiche" meta_type="CMF Action" remove="True">
+   <property name="title">Servizi</property>
+   <property name="description"></property>
+   <property
+      name="url_expr">string:${globals_view/navigationRootUrl}/#</property>
+   <property name="link_target"></property>
+   <property name="icon_expr"></property>
+   <property name="available_expr"></property>
+   <property name="permissions"/>
+   <property name="visible">True</property>
+  </object>
+  <object name="amministrazione" meta_type="CMF Action" remove="True">
+   <property name="title">L'Amministrazione</property>
+   <property name="description"></property>
+   <property
+      name="url_expr">string:${globals_view/navigationRootUrl}/#</property>
+   <property name="link_target"></property>
+   <property name="icon_expr"></property>
+   <property name="available_expr"></property>
+   <property name="permissions"/>
+   <property name="visible">True</property>
+  </object>
+  <object name="vivere" meta_type="CMF Action" remove="True">
+   <property name="title">Vivere il Comune</property>
+   <property name="description"></property>
+   <property
+      name="url_expr">string:${globals_view/navigationRootUrl}/#</property>
+   <property name="link_target"></property>
+   <property name="icon_expr"></property>
+   <property name="available_expr"></property>
+   <property name="permissions"/>
+   <property name="visible">True</property>
+  </object>
+ </object>
+
+</object>

--- a/src/redturtle/agidtheme/profiles/uninstall/controlpanel.xml
+++ b/src/redturtle/agidtheme/profiles/uninstall/controlpanel.xml
@@ -6,9 +6,8 @@
     <configlet
         title="Configurazione tema agid"
         action_id="redturtle-agidtheme-controlpanel"
-        appId="redturtle.agidtheme"
-        remove="true">
-
+        remove="True"
+        appId="redturtle.agidtheme">
     </configlet>
 
 </object>

--- a/src/redturtle/agidtheme/profiles/uninstall/registry.xml
+++ b/src/redturtle/agidtheme/profiles/uninstall/registry.xml
@@ -1,34 +1,88 @@
 <?xml version="1.0"?>
 <registry>
+  <record name="plone.templates" interface="Products.CMFPlone.interfaces.controlpanel.ITinyMCESchema" field="templates">
+    <field type="plone.registry.field.Text">
+      <default></default>
+      <description xmlns:ns0="http://xml.zope.org/namespaces/i18n" ns0:domain="plone" ns0:translate="help_tinymce_templates">Enter the list of templates in json format                 http://www.tinymce.com/wiki.php/Plugin:template</description>
+      <required>False</required>
+      <title xmlns:ns0="http://xml.zope.org/namespaces/i18n" ns0:domain="plone" ns0:translate="label_tinymce_templates">Templates</title>
+    </field>
+    <value></value>
+  </record>
 
-  <!-- RESOURCE -->
-  <records prefix="plone.resources/redturtle-agidtheme-css"
-           interface='Products.CMFPlone.interfaces.IResourceRegistry'
-           remove="True"
-           />
-  <records prefix="plone.resources/redturtle-agidtheme-js"
-           interface='Products.CMFPlone.interfaces.IResourceRegistry'
-           remove="True"
-           />
+  <records interface="Products.CMFPlone.interfaces.controlpanel.ITinyMCESchema" prefix="plone">
+    <field type="plone.registry.field.List"></field>
+    <value purge="true" key="table_styles">
+      <element remove="True">Semplice|table-simple</element>
+      <element remove="True">Bordi visibili|table-bordered</element>
+      <element remove="True">A righe alternate|table-striped</element>
+      <element remove="True">Con effetto hover|table-hover</element>
+    </value>
+  </records>
 
-  <!-- BUNDLE -->
-  <records prefix="plone.bundles/redturtle-agidtheme-css-bundle"
-           interface='Products.CMFPlone.interfaces.IBundleRegistry'
-           remove="True"
-           />
-  <records prefix="plone.bundles/redturtle-agidtheme-js-bundle"
-           interface='Products.CMFPlone.interfaces.IBundleRegistry'
-           remove="True"
-           />
+  <record interface="Products.CMFPlone.interfaces.controlpanel.ILinkSchema" name="plone.mark_special_links" field="mark_special_links">
+    <field type="plone.registry.field.Bool">
+      <default>True</default>
+    </field>
+  </record>
 
-  <record name="plone.allowed_sizes" interface="Products.CMFPlone.interfaces.controlpanel.IImagingSchema" field="allowed_sizes">
-    <value purge="false">
-      <element remove="true">newshome 300:200</element>
-      <element remove="true">newshome 450:300</element>
-      <element remove="true">newshighlight 540:360</element>
-      <element remove="true">newsbig 1800:600</element>
+  <record interface="Products.CMFPlone.interfaces.controlpanel.ISecuritySchema" name="plone.allow_anon_views_about" field="allow_anon_views_about">
+    <field type="plone.registry.field.Bool">
+      <default>True</default>
+    </field>
+  </record>
+  <record interface="Products.CMFPlone.interfaces.controlpanel.ISiteSchema" name="plone.display_publication_date_in_byline" field="display_publication_date_in_byline">
+    <field type="plone.registry.field.Bool">
+      <default>False</default>
+    </field>
+  </record>
+
+  <record name="plone.custom_tags" interface="Products.CMFPlone.interfaces.controlpanel.IFilterSchema" field="custom_tags">
+    <field type="plone.registry.field.List">
+      <default/>
+      <description xmlns:ns0="http://xml.zope.org/namespaces/i18n" ns0:domain="plone" ns0:translate="">Add tag names here for tags which are not part of XHTML but which should be permitted.</description>
+      <missing_value/>
+      <required>False</required>
+      <title xmlns:ns0="http://xml.zope.org/namespaces/i18n" ns0:domain="plone" ns0:translate="">Custom tags</title>
+      <value_type type="plone.registry.field.TextLine"/>
+    </field>
+    <value>
+      <element remove="True">hr</element>
     </value>
   </record>
 
-</registry>
+  <record name="plone.allowed_sizes" interface="Products.CMFPlone.interfaces.controlpanel.IImagingSchema" field="allowed_sizes">
+    <value purge="false">
+      <element remove="True">newshome 450:300</element>
+      <element remove="True">newshighlight 540:360</element>
+      <element remove="True">newsbig 1800:600</element>
+    </value>
+  </record>
 
+  <records interface="redturtle.agidtheme.controlpanel.interfaces.IRedturtleAgidthemeSettings" remove="True"/>
+
+  <!-- RESOURCES -->
+  <records prefix="plone.resources/redturtle-agidtheme-css"
+           interface='Products.CMFPlone.interfaces.IResourceRegistry' remove="True">
+  </records>
+  <records prefix="plone.resources/redturtle-agidtheme-js"
+           interface='Products.CMFPlone.interfaces.IResourceRegistry'  remove="True">
+  </records>
+  <records prefix="plone.resources/redturtle-agidtheme-icons"
+           interface='Products.CMFPlone.interfaces.IResourceRegistry' remove="True">
+  </records>
+
+  <!-- BUNDLES -->
+  <records prefix="plone.bundles/redturtle-agidtheme-css-bundle"
+           interface='Products.CMFPlone.interfaces.IBundleRegistry' remove="True">
+  </records>
+  <records prefix="plone.bundles/redturtle-agidtheme-js-bundle"
+           interface='Products.CMFPlone.interfaces.IBundleRegistry' remove="True">
+  </records>
+  <records prefix="plone.bundles/redturtle-agidtheme-icons-bundle"
+           interface='Products.CMFPlone.interfaces.IBundleRegistry' remove="True">
+  </records>
+
+  <record name="collective.tiles.advancedstatic.css_styles" remove="True">
+  </record>
+</registry>

--- a/src/redturtle/agidtheme/profiles/uninstall/types/Document.xml
+++ b/src/redturtle/agidtheme/profiles/uninstall/types/Document.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<object
+    i18n:domain="plone"
+    meta_type="Dexterity FTI"
+    name="Document"
+    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+  <property
+      name="view_methods"
+      purge="false">
+    <element remove="True" value="tiles_page_view" />
+  </property>
+  <property
+      name="behaviors"
+      purge="false">
+    <element value="plone.layoutaware" remove="True"/>
+    <element value="redturtle.agidtheme.behaviors.behavior.IClassOnView" remove="True"/>
+  </property>
+</object>

--- a/src/redturtle/agidtheme/profiles/uninstall/types/Event.xml
+++ b/src/redturtle/agidtheme/profiles/uninstall/types/Event.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<object
+    i18n:domain="plone"
+    meta_type="Dexterity FTI"
+    name="Event"
+    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+  <!-- Enabled behaviors -->
+  <property name="behaviors" purge="false">
+    <element value="plone.app.contenttypes.behaviors.leadimage.ILeadImage" remove="True"/>
+  </property>
+
+</object>

--- a/src/redturtle/agidtheme/profiles/uninstall/types/Folder.xml
+++ b/src/redturtle/agidtheme/profiles/uninstall/types/Folder.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<object
+    i18n:domain="plone"
+    meta_type="Dexterity FTI"
+    name="Folder"
+    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+  <property
+      name="behaviors"
+      purge="false">
+    <element value="plone.layoutaware" remove="True" />
+  </property>
+
+  <property
+      name="behaviors"
+      purge="false">
+    <element value="plone.app.contenttypes.behaviors.leadimage.ILeadImage" remove="True" />
+  </property>
+
+</object>

--- a/src/redturtle/agidtheme/profiles/uninstall/viewlets.xml
+++ b/src/redturtle/agidtheme/profiles/uninstall/viewlets.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<object>
+  <order manager="plone.portalheader" skinname="Plone Default">
+    <viewlet name="plone.logo" />
+    <viewlet name="plone.app.i18n.locales.languageselector" />
+    <viewlet name="redturtle.header.social" />
+    <viewlet name="plone.searchbox" />
+    <viewlet name="plone.anontools" />
+  </order>
+  <order manager="plone.belowcontent" skinname="Plone Default">
+    <viewlet name="plone.abovecontenttitle.documentactions" />
+    <viewlet name="plone.belowcontenttitle.documentbyline" />
+    <viewlet name="plone.belowcontenttitle.keywords" />
+    <viewlet name="plone.belowcontentbody.relateditems" />
+    <viewlet name="plone.nextprevious" />
+    <viewlet name="plone.comments" />
+  </order>
+  <order manager="plone.portaltop" skinname="Plone Default">
+    <viewlet name="redturtle.skip_links" before="*" />
+    <viewlet name="redturtle.header_banner" before="*" />
+    <viewlet name="plone.header" />
+  </order>
+  <hidden manager="plone.belowcontentbody" skinname="Plone Default">
+    <viewlet name="plone.abovecontenttitle.documentactions" />
+    <viewlet name="plone.belowcontentbody.relateditems" />
+  </hidden>
+  <hidden manager="plone.belowcontenttitle" skinname="Plone Default">
+    <viewlet name="plone.belowcontenttitle.documentbyline" />
+  </hidden>
+  <hidden manager="plone.abovecontenttitle" skinname="Plone Default">
+    <viewlet name="contentleadimage" />
+  </hidden>
+</object>


### PR DESCRIPTION
@pnicolli said:

Ottimo. In generale, si può rimuovere un record o un oggetto dall'xml anche senza includere tutto il suo contenuto, questo renderebbe molto più veloce da leggere il tutto. Ad esempio:

```xml
<object name="aree-tematiche" meta_type="CMF Action" remove="True">
  <property name="title">Servizi</property>
  <property name="description"></property>
  <property
     name="url_expr">string:${globals_view/navigationRootUrl}/#</property>
  <property name="link_target"></property>
  <property name="icon_expr"></property>
  <property name="available_expr"></property>
  <property name="permissions"/>
  <property name="visible">True</property>
</object>
```

può diventare:

```xml
<object name="aree-tematiche" meta_type="CMF Action" remove="True" />
```
